### PR TITLE
Don't crash when felid mummies use Call Merchant

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4491,7 +4491,7 @@ bool gozag_call_merchant()
         // first index.
         if (type == SHOP_FOOD)
             continue;
-        if (type == SHOP_DISTILLERY && you.species == SP_MUMMY || you.species == SP_FELID_MUMMY)
+        if (type == SHOP_DISTILLERY && (you.species == SP_MUMMY || you.species == SP_FELID_MUMMY))
             continue;
         if (type == SHOP_EVOKABLES && you.get_mutation_level(MUT_NO_ARTIFICE))
             continue;


### PR DESCRIPTION
Not being able to use Call Merchant does add some difficulty but being able to crash the game on demand is a pretty strong perk for this race and probably not intended.