### PR TITLE
Slime Priest Improvements 👌 

### DIFF
--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -269,7 +269,7 @@ static void _give_items_skills(const newgame_def& ng)
 		
     case JOB_SLIME_PRIEST:
         you.religion = GOD_JIYVA;
-        you.piety = 35;
+        you.piety = 5;
 
         if (species_apt(SK_ARMOUR) < species_apt(SK_DODGING))
             you.skills[SK_DODGING]++;
@@ -676,6 +676,14 @@ static void _setup_generic(const newgame_def& ng)
     // Make sure the starting player is fully charged up.
     set_hp(you.hp_max);
     set_mp(you.max_magic_points);
+
+    //Mutate Slime Priest
+    if (you.char_class == JOB_SLIME_PRIEST)
+    {
+        mutate(RANDOM_SLIME_MUTATION, "Slime Spawn's Curse", false);
+        mutate(RANDOM_MUTATION, "Slime Spawn's Curse", false);
+        mutate(RANDOM_MUTATION, "Slime Spawn's Curse", false);
+    }
 
     initialise_branch_depths();
     initialise_temples();


### PR DESCRIPTION
Starting

- Start game with minimal piety
  - If you just hold wait you still gain piety faster than the idle degradation, keeping start piety low lowers the benefit of choosing a zealot
- To make up for it, get some neat mutations instead!
